### PR TITLE
Add commit-msg hook to lint commit messages

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/bash
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm exec commitlint --config "$(dirname "$0")/../config/commitlint/commitlint.config.js" --edit ""

--- a/config/commitlint/commitlint.config.js
+++ b/config/commitlint/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ["@commitlint/config-conventional"] };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
+    "prepare": "husky install",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
@@ -26,10 +27,14 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
+    "@commitlint/cli": "17.0.3",
+    "@commitlint/config-conventional": "17.0.3",
+    "@commitlint/prompt-cli": "17.0.3",
     "@docusaurus/module-type-aliases": "2.0.0-beta.21",
     "@docusaurus/plugin-content-docs": "2.0.0-beta.21",
     "@docusaurus/types": "2.0.0-beta.21",
     "@tsconfig/docusaurus": "1.0.6",
+    "husky": "8.0.1",
     "typescript": "4.7.4"
   },
   "browserslist": {


### PR DESCRIPTION
### Added
- Added `commit-msg` hook to lint commit messages.