### PR TITLE
Add container module metadata page

### DIFF
--- a/docs/concepts/container-module-metadata.md
+++ b/docs/concepts/container-module-metadata.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 3
+title: Container module metadata
+---
+
+Represents configuration to build and load a container module.
+
+`ContainerModuleMetadata` can be of four different different kinds:
+
+### ContainerModuleFactoryMetadata
+
+Represents a container module to be built using a factory.
+
+| Property             | Description                               | Type                      |
+| :---                 | :----:                                    | :---:                     |
+| id                   | ContainerModuleMetadata id                | ContainerModuleMetadataId |
+| imports              | Dependencies required to build the module | ContainerModuleMetadata[] |
+| factory              | Function to build the module              | Function                  |
+| injects              | Services to be passed as arguments        | ServiceId[]               |
+
+### ContainerModuleClassMetadata
+
+Represents a container module to be built using a decorated ContainerModule class.
+
+| Property             | Description                               | Type                               |
+| :---                 | :----:                                    | :---:                              |
+| id                   | ContainerModuleMetadata id                | ContainerModuleMetadataId          |
+| imports              | Dependencies required to build the module | ContainerModuleMetadata[]          |
+| module               | ContainerModuleMetadaClass to be loaded   | Newable&#60ContainerModuleMetadata&#62 |
+
+### ContainerModule
+
+Represents a ContainerModule instance to be loaded. Equivalent to a `ContainerModuleFactoryMetadata` with a factory with no arguments returning the module.
+
+### Newable&#60ContainerModule&#62
+
+Represents a `ContainerModule` class to be instantiated in order to load a container module. Equivalent to a `ContainerModuleClassMetadata` with no the class as module.

--- a/docs/tutorial/container-modules/loading-modules-from-metadata.md
+++ b/docs/tutorial/container-modules/loading-modules-from-metadata.md
@@ -89,3 +89,5 @@ async function entryPoint(): Promise<void> {
 Optionally, a container module metadata class can be passed insted. This is equivalent to a metadata with the class as module and no imports.
 
 This approach is highly inspired on [NestJs modules](https://docs.nestjs.com/fundamentals/dynamic-modules).
+
+Consider the [ContainerModuleMetadata](../../concepts/container-module-metadata.md) page as reference to know more about `ContainerModuleMetadata` details.


### PR DESCRIPTION
### Added
- Added `ContainerModuleMetadata` page.

### Changed
- Updated tutorial to properly reference `ContainerModuleMetadata` page.